### PR TITLE
Adding datetime support

### DIFF
--- a/pymongolite/backend/storage_engine/files_engine.py
+++ b/pymongolite/backend/storage_engine/files_engine.py
@@ -19,7 +19,7 @@ from pymongolite.backend.storage_engine.base_engine import BaseEngine
 from pymongolite.backend.storage_engine.insert_instruction import InsertInstructions
 from pymongolite.backend.read_instructions import ReadInstructions
 from pymongolite.backend.storage_engine.update_instructions import UpdateInstructions
-
+from pymongolite.backend.storage_engine.serialization_helpers import MongoLiteJSONDecoder, MongoLiteJSONEncoder
 
 class FilesEngine(BaseEngine):
     def __init__(self, dirpath: Union[str, Path], **kwargs):
@@ -57,10 +57,10 @@ class FilesEngine(BaseEngine):
         return self._get_database_path(database_name) / collection_name
 
     def _serialize_document(self, document: dict) -> str:
-        return json.dumps(document)
+        return json.dumps(document, cls=MongoLiteJSONEncoder)
 
     def _deserialize_document(self, serialized_document: str) -> dict:
-        return json.loads(serialized_document)
+        return json.loads(serialized_document, cls=MongoLiteJSONDecoder)
 
     def _mark_document_as_deleted(self, file, index: int):
         file.seek(index)

--- a/pymongolite/backend/storage_engine/serialization_helpers.py
+++ b/pymongolite/backend/storage_engine/serialization_helpers.py
@@ -1,0 +1,22 @@
+import json
+from datetime import datetime
+
+class MongoLiteJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return {"$date":obj.isoformat()}
+
+        return super().default(obj)
+
+
+class MongoLiteJSONDecoder(json.JSONDecoder):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, object_hook=self.object_hook,
+                         **kwargs)
+
+    def object_hook(self, d): 
+        if '$date' in d:
+            return datetime.fromisoformat(d['$date'])
+            
+        return d

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,10 +1,11 @@
-import os
+import os, datetime
 import shutil
 
 import pytest
 
 from pymongolite import MongoClient
 
+type_test_list = ["a string", 1, 1.002, True, datetime.datetime.now(), ["1", "2", "3", 2, True], {"1": 2, "2": 2.3, "3": datetime.datetime.now(), "4": True}, None]
 
 @pytest.fixture(scope="function")
 def collection():
@@ -30,6 +31,19 @@ def test_insert(collection):
 
     assert data.startswith('{"a": true')
 
+@pytest.mark.parametrize("type_example", type_test_list, ids=[type(v) for v in type_test_list])
+def test_all_pymongo_supported_types(collection, type_example):
+    """Test all pymongo supported serialization/deserialization types per 
+    https://www.mongodb.com/docs/languages/python/pymongo-driver/upcoming/serialization/
+    """
+    collection.insert_one({"test_type": type_example})
+
+    doc = collection.find_one({})
+
+    type_out = doc["test_type"]
+
+    assert type(type_out) == type(type_example)
+    assert type_out == type_example
 
 def test_insert_many(collection):
     collection.insert_many([{"a": True}, {"b": False}])


### PR DESCRIPTION
 * pymongo [docs](https://www.mongodb.com/docs/languages/python/pymongo-driver/upcoming/serialization/) indicate they support serialization for datetime, so added it here
   * Used same `{"$date":<iso>}` format mongo uses
 * Added tests for all types indicated to be supported per the aforementioned docs
 * Closes #11 